### PR TITLE
Setup a GitHub action to lint the project

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        distribution: zulu
+        java-version: '11'
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Lint with Gradle
+      run: ./gradlew spotlessCheck

--- a/build.gradle
+++ b/build.gradle
@@ -70,3 +70,11 @@ tasks.named('generateJava') {
     schemaPaths = ["${projectDir}/src/main/resources/schema"] // List of directories containing schema files
     packageName = 'io.spring.graphql' // The package name to use to generate sources
 }
+
+tasks.register('spotlessCheck') {
+    dependsOn 'spotlessJavaCheck'
+}
+
+tasks.register('spotlessApply') {
+    dependsOn 'spotlessJavaApply'
+}


### PR DESCRIPTION
Add a GitHub action to lint the project on each commit to the remote branch.

* **build.gradle**
  - Add `spotlessCheck` task to check code formatting.
  - Add `spotlessApply` task to apply code formatting.

* **.github/workflows/lint.yml**
  - Create a new GitHub Actions workflow file named `lint.yml`.
  - Add a name for the workflow: "Lint".
  - Trigger the workflow on push and pull request events for all branches and tags.
  - Add a job named `lint` that runs on `ubuntu-latest`.
  - Add steps to set up JDK 11, cache Gradle dependencies, and run the `spotlessCheck` task.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WZHVIKR/spring-boot-realworld-example-app/pull/2?shareId=06b22a8c-dbe0-4447-b919-9408b13f4c9a).